### PR TITLE
Feat: Token 인증 API 추가

### DIFF
--- a/src/main/java/camandedit/server/global/exception/AuthenticationFailException.java
+++ b/src/main/java/camandedit/server/global/exception/AuthenticationFailException.java
@@ -1,0 +1,8 @@
+package camandedit.server.global.exception;
+
+public class AuthenticationFailException extends BusinessException {
+
+    public AuthenticationFailException(String message) {
+        super(message, ErrorType.AUTHENTICATION_FAIL);
+    }
+}

--- a/src/main/java/camandedit/server/global/exception/ErrorType.java
+++ b/src/main/java/camandedit/server/global/exception/ErrorType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum ErrorType {
   INVALID_INPUT(400),
-  EXPIRED_JWT(400),
+  EXPIRED_JWT(401),
   AUTHENTICATION_FAIL(401),
   AUTHORIZATION_FAIL(403),
   NOT_FOUND_RESOURCE(404),

--- a/src/main/java/camandedit/server/user/controller/AuthController.java
+++ b/src/main/java/camandedit/server/user/controller/AuthController.java
@@ -1,0 +1,19 @@
+package camandedit.server.user.controller;
+
+import camandedit.server.global.response.JsonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+
+    @GetMapping("/api/auth/check")
+    public ResponseEntity<?> checkToken() {
+        return JsonResponse.ok(HttpStatus.OK, "인증 성공");
+    }
+}

--- a/src/main/java/camandedit/server/user/exception/InvalidJwtException.java
+++ b/src/main/java/camandedit/server/user/exception/InvalidJwtException.java
@@ -6,6 +6,6 @@ import camandedit.server.global.exception.ErrorType;
 public class InvalidJwtException extends BusinessException {
 
   public InvalidJwtException(String message) {
-    super(message, ErrorType.INVALID_INPUT);
+    super(message, ErrorType.AUTHENTICATION_FAIL);
   }
 }


### PR DESCRIPTION
# 개발사항

- Token 확인 API 추가 /api/auth/check

## 세부사항

###  Token 확인 API 추가

-  Token 확인 API 추가
- 시큐리티의 인증 기능을 다 통과하면 Controller에서 리턴 시킴
- JWT 이상 시 401 리턴

- 토큰 인증 방식은 추 후 변경

Closed #3 
